### PR TITLE
[ Fix ] 정렬 api 제거 및 수정, 채팅 기능 에러 수정

### DIFF
--- a/src/components/home/Friend.tsx
+++ b/src/components/home/Friend.tsx
@@ -28,6 +28,7 @@ const FriendRequestUserList = () => {
     status: 0,
     userID: Number(Cookies.get('user_index')),
     userEmail: '',
+    university: '',
   });
   const { userID, friendUserID, status } = requestData;
 

--- a/src/constants/boardSortingValue.ts
+++ b/src/constants/boardSortingValue.ts
@@ -1,1 +1,1 @@
-export const sortValues = ['최신순', '오래된 순', '이름순'];
+export const sortValues = ['정렬선택', '최신순', '오래된 순', '이름순'];

--- a/src/pages/api/chat/chatting.ts
+++ b/src/pages/api/chat/chatting.ts
@@ -36,7 +36,6 @@ export default async function handler(
 
         // 상대방 ID와 매칭되는 사용자 찾기
         const matchingUser = userRow.find((u) => u.user_index === friendUserId);
-        console.log('matchingUser: ', matchingUser);
         return {
           ...d,
           chat_user_nickname: matchingUser ? matchingUser.user_nickname : null, // 닉네임 추가

--- a/src/pages/api/chat/index.ts
+++ b/src/pages/api/chat/index.ts
@@ -20,7 +20,7 @@ const chatHandler = async (
       const senderID = chat_user_id;
       // const receiverID = 38;
 
-      console.log('message: ', message);
+      // console.log('message: ', message);
 
       await connection.execute<RowDataPacket[]>(
         `SELECT * FROM user WHERE user_index = ? `,
@@ -29,7 +29,7 @@ const chatHandler = async (
 
       // 친구인지 판별하는 쿼리
       const [areWeFriends] = await connection.execute<RowDataPacket[]>(
-        'SELECT * FROM friend WHERE (userID = ? AND friendUserID = ?) OR (userID = ? AND friendUserID = ?)',
+        'SELECT * FROM friend WHERE (userID = ? AND friendUserID = ? AND status = 1) OR (userID = ? AND friendUserID = ? AND status = 1)',
         [chat_user_id, receiverID, receiverID, chat_user_id]
       );
 
@@ -41,14 +41,14 @@ const chatHandler = async (
           [chat_user_id, chat_content, senderID, receiverID]
         );
 
-        console.log('채팅 생성 성공', createChat);
+        // console.log('채팅 생성 성공', createChat);
 
         const [getChat] = await connection.execute(
           'SELECT * FROM chat WHERE chat_id = ?',
           [createChat.insertId]
         );
 
-        console.log('채팅 생성 후 데이터 가져오기: ', getChat);
+        // console.log('채팅 생성 후 데이터 가져오기: ', getChat);
 
         const changeType = getChat as ChatDataType[];
 

--- a/src/pages/api/friend/index.ts
+++ b/src/pages/api/friend/index.ts
@@ -71,7 +71,11 @@ export default async function handler(
           (user) => user.user_index === request.userID
         );
 
-        return { ...request, userEmail: user ? user.user_nickname : null };
+        return {
+          ...request,
+          userEmail: user ? user.user_nickname : null,
+          university: user?.university,
+        };
       });
 
       const newData3 = myRequestFromFriend.map((request) => {
@@ -79,7 +83,11 @@ export default async function handler(
           (user) => user.user_index === request.friendUserID
         );
 
-        return { ...request, userEmail: user ? user.user_nickname : null };
+        return {
+          ...request,
+          userEmail: user ? user.user_nickname : null,
+          university: user?.university,
+        };
       });
 
       const allRequests = [...newData2, ...newData3];

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -361,16 +361,29 @@ const Home = () => {
   };
 
   function sortingBoards(value: string) {
+    let sorting;
+
     switch (value) {
       case '최신순':
-        getDateDescendDataFunc();
+        sorting = [...infiniteBoardData].sort((a, b) =>
+          b.createdAt.localeCompare(a.createdAt)
+        );
+        setInfiniteBoardData(sorting);
         break;
       case '오래된 순':
-        getDateAscendDataFunc();
+        sorting = [...infiniteBoardData].sort((a, b) =>
+          a.createdAt.localeCompare(b.createdAt)
+        );
+        setInfiniteBoardData(sorting);
         break;
       case '이름순':
-        getContentAscendDataFuncs();
+        sorting = [...infiniteBoardData].sort((a, b) =>
+          a.board_title.localeCompare(b.board_title)
+        );
+        setInfiniteBoardData(sorting);
         break;
+      default:
+        break; // 기본값 추가
     }
   }
 

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -228,9 +228,9 @@ export const Nav = styled.nav`
   .sortButton {
     width: auto;
     height: 30px;
-    padding: 10px;
     display: flex;
     align-items: center;
+    text-align: center;
     border: 1px solid #e2e2e2;
     background-color: #f5f5f5;
     font-family: 'GmarketSansMedium';

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -42,6 +42,7 @@ export interface pagingType {
 }
 
 export interface userRequestType {
+  university: string;
   createAt: string;
   friendUserID: number;
   id: number;


### PR DESCRIPTION
<!-- 제목: [Feature] PR내용
ex) [Feature] 프로젝트 초기 세팅 -->

## 이슈 번호
#36 
## 구현 내용
- 정렬 api 제거하고 클라이언트 측에서 처리하기
- 채팅 리스트 쪽 기능 에러 수정

## 관련 기술 설명
문제 상황
- 친구가 아닌 경우에도 메시지가 보내짐
- 친구 리스트가 메시지를 주고 받은 경우에만 친구 리스트에 뜸 메시지를 주고 받지 않은 경우에도 친구라면 친구 리스트에 있어야하게 변경해야함

api에서 서로 친구 요청을 보낸 경우에 메세지를 보낼 수 있게 했는데 이게 에러이다.
서로 친구인지를 status 컬럼으로 1이어야 하는데 0인 값도 모두 메세지를 보낼 수 있게 설정해서 친구가 아닌 유저에게도 메세지를 보낼 수 있었음

채팅방 데이터가 데이터가 있어야 컴포넌트가 전환되는 것을 초기값을 넣어줘서 처리해서 해결함
추가 수정 사항으로 기본 값이 들어가 있어서 ui가 깨지는 현상을 메시지 내용이 있으면 렌더링 할 수 있게 변환하여 해결함

문제상황
- 정렬 api를 이용하게 되면 전체 데이터를 setState 함수에 할당하게 돼서 무한 스크롤 로직이 망가지게 됌

TanStack Query 데이터를 직접 sort 함수를 사용해서 정렬을 했는데 리렌더링이 일어나지 않음
이유는?? Array.prototype.sort() 메서드가 원본 배열을 정렬하고 동일한 참조를 반환하기 때문
React에서는 상태가 변경되었을 때 UI를 업데이트하는데, 상태 값이 변경되지 않으면 재렌더링이 발생하지 않는다.

그러므로 스프레드 문법과 let 변수를 이용해 기존 데이터를 복사한 후에 sort 메서드를 적용해서 해결